### PR TITLE
Fix consumer MCP regression: pin scopes_supported to ['coinstats']

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -29,11 +29,21 @@ function resolveResourceUrl(env: Env, request: Request): string {
 /**
  * RFC 9728 Protected Resource Metadata. MCP clients fetch this to
  * discover which authorization server can issue tokens for this MCP.
+ *
+ * `scopes_supported` is advertised explicitly so MCP clients know which
+ * scope to request for THIS resource. Without it, clients fall back to
+ * the AS metadata's `scopes_supported`, which now lists ['coinstats',
+ * 'admin'] (admin scope was added for the internal admin-MCP). Claude.ai
+ * then requests both, and cloud rejects the combination with
+ * `invalid_scope: admin scope cannot be combined with other scopes`.
+ * Pinning to ['coinstats'] here keeps the consumer MCP's authorization
+ * flow correct regardless of what the AS supports globally.
  */
 function protectedResourceMetadata(env: Env, request: Request) {
     return {
         resource: resolveResourceUrl(env, request),
         authorization_servers: [env.OAUTH_ISSUER],
+        scopes_supported: ['coinstats'],
         bearer_methods_supported: ['header'],
     };
 }


### PR DESCRIPTION
## Summary

- After cloud slice 1 added the \`admin\` scope to the AS, MCP clients connecting to \`mcp.coinstats.app\` started requesting \`scope=coinstats admin\` (falling back to the AS's \`scopes_supported\` list because the resource metadata didn't pin its own).
- Cloud's \`rejectMixedScope\` rejects that combination with \`invalid_scope: admin scope cannot be combined with other scopes\`, which surfaces on the consent UI and blocks consumer sign-in entirely.
- Pin \`scopes_supported: ['coinstats']\` on the resource metadata so clients only request the scope this resource actually accepts, regardless of what the AS supports globally.

## Test plan

- [ ] Deploy worker; \`curl https://mcp.coinstats.app/.well-known/oauth-protected-resource\` returns \`scopes_supported: ["coinstats"]\`
- [ ] Re-connect from Claude.ai / a fresh client; consent UI loads without the mixed-scope error
- [ ] Existing tokens continue to work (no token-side changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)