### PR TITLE
Fix exchange connection: give connectionFields a real schema

### DIFF
--- a/src/services/request.ts
+++ b/src/services/request.ts
@@ -31,25 +31,22 @@ export async function makeRequestCsApi<T>(
         'Content-Type': 'application/json',
     };
 
-    try {
-        const options: RequestInit = { method, headers };
+    const options: RequestInit = { method, headers };
 
-        if (method !== 'GET' && body) {
-            options.body = JSON.stringify(body);
-        }
-
-        const queryParams = new URLSearchParams(params);
-        const queryString = queryParams.toString();
-        const urlWithParams = queryString ? `${url}?${queryString}` : url;
-
-        const response = await fetch(urlWithParams, options);
-        if (!response.ok) {
-            throw new Error(`HTTP error! status: ${response.status}`);
-        }
-        return (await response.json()) as T;
-    } catch (error) {
-        return null;
+    if (method !== 'GET' && body) {
+        options.body = JSON.stringify(body);
     }
+
+    const queryParams = new URLSearchParams(params);
+    const queryString = queryParams.toString();
+    const urlWithParams = queryString ? `${url}?${queryString}` : url;
+
+    const response = await fetch(urlWithParams, options);
+    if (!response.ok) {
+        const errorBody = await response.text();
+        throw new Error(`CoinStats API error ${response.status}: ${errorBody || response.statusText}`);
+    }
+    return (await response.json()) as T;
 }
 
 /**
@@ -117,8 +114,9 @@ export async function universalApiHandler<T>(
             ],
         };
     } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
         return {
-            content: [{ type: 'text', text: `Error: ${error}`, isError: true }],
+            content: [{ type: 'text', text: `Error: ${message}`, isError: true }],
         };
     }
 }

--- a/src/tools/toolConfigs.ts
+++ b/src/tools/toolConfigs.ts
@@ -248,7 +248,19 @@ export const allToolConfigs: ToolConfig<any>[] = [
         endpoint: '/exchange/balance',
         method: 'POST',
         parameters: {
-            connectionFields: z.object({}).describe('The credentials given from exchange. key, secret etc.'),
+            connectionFields: z
+                .object({
+                    apiKey: z.string().optional().describe('Exchange API key'),
+                    apiSecret: z.string().optional().describe('Exchange API secret'),
+                    passphrase: z
+                        .string()
+                        .optional()
+                        .describe('API passphrase — required by some exchanges (e.g. Bitget, OKX, KuCoin)'),
+                })
+                .passthrough()
+                .describe(
+                    'Exchange API credentials. Required fields vary per exchange — call get-exchanges (/exchange/support) for the exact fields a given connectionId needs. Common fields: apiKey, apiSecret, passphrase.'
+                ),
             connectionId: z.string().describe('The exchange connection id'),
         },
     },


### PR DESCRIPTION
## Summary

Connecting an exchange (e.g. Bitget with `apiKey`/`apiSecret`/`passphrase`) failed through the MCP even though the identical body worked against the CoinStats API directly.

**Root cause:** `get-exchange-balance` declared `connectionFields: z.object({})` — an empty Zod object with zero properties. On the stdio path the SDK's Zod `.parse()` stripped the credentials; on the hosted Worker path the advertised `inputSchema` exposed `connectionFields` with no documented properties (and `additionalProperties: false`), so the model never learned to nest them. Either way CoinStats received empty credentials.

- `connectionFields` now documents `apiKey`/`apiSecret`/`passphrase` and uses `.passthrough()` so exchange-specific fields are preserved and advertised as `additionalProperties: true`.
- `makeRequestCsApi` now throws the real CoinStats status + body instead of swallowing it into a generic `"Something went wrong"`; `universalApiHandler` surfaces a clean single-prefixed message.

## Test plan

- [x] `npm run build:js` (tsc) passes clean
- [x] `tools/list` now exposes `connectionFields` with the three documented properties and `additionalProperties: true`
- [x] `get-exchange-balance` passes the full `{connectionId, connectionFields:{...}}` body through to CoinStats `/exchange/balance` (credentials no longer stripped); error surfacing returns the real CoinStats status + message
- [ ] Confirm success path with a valid CoinStats API key + real Bitget credentials returns a balance/`portfolioId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)