### PR TITLE
Fix consumer MCP OAuth scopes

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "build": "npm i && npm run build:types && npm run build:js && shx chmod +x dist/index.js",
         "build:js": "tsc",
         "build:types": "tsc --emitDeclarationOnly",
+        "test": "node --test test/*.test.mjs",
         "dev": "wrangler dev",
         "deploy": "wrangler deploy",
         "tail": "wrangler tail"

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -12,6 +12,7 @@ interface Env {
 const SERVER_NAME = 'coinstats-mcp';
 const SERVER_VERSION = '2.0.0';
 const DEFAULT_PROTOCOL_VERSION = '2025-06-18';
+const CONSUMER_MCP_SCOPES = ['coinstats'];
 
 /**
  * Resolve this MCP server's canonical URL. Prefer the env-configured
@@ -43,9 +44,24 @@ function protectedResourceMetadata(env: Env, request: Request) {
     return {
         resource: resolveResourceUrl(env, request),
         authorization_servers: [env.OAUTH_ISSUER],
-        scopes_supported: ['coinstats'],
+        scopes_supported: CONSUMER_MCP_SCOPES,
         bearer_methods_supported: ['header'],
     };
+}
+
+function withConsumerMcpScopes(body: string): string {
+    try {
+        const metadata = JSON.parse(body);
+        if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+            return body;
+        }
+        return JSON.stringify({
+            ...metadata,
+            scopes_supported: CONSUMER_MCP_SCOPES,
+        });
+    } catch {
+        return body;
+    }
 }
 
 function unauthorized(env: Env, request: Request, description: string): Response {
@@ -264,7 +280,9 @@ export default {
                     headers: { Accept: 'application/json' },
                     cf: { cacheTtl: 3600, cacheEverything: true },
                 });
-                const body = await res.text();
+                // Older MCP clients may read this mirror directly and request
+                // every advertised scope, so keep it resource-scoped too.
+                const body = withConsumerMcpScopes(await res.text());
                 return new Response(body, {
                     status: res.status,
                     headers: {

--- a/test/worker-oauth-metadata.test.mjs
+++ b/test/worker-oauth-metadata.test.mjs
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import vm from 'node:vm';
+import ts from 'typescript';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+const workerPath = path.join(repoRoot, 'src', 'worker.ts');
+
+function loadWorker(fetchStub) {
+    const source = fs.readFileSync(workerPath, 'utf8');
+    const compiled = ts.transpileModule(source, {
+        compilerOptions: {
+            target: ts.ScriptTarget.ES2022,
+            module: ts.ModuleKind.CommonJS,
+            esModuleInterop: true,
+        },
+    }).outputText;
+
+    const moduleExports = {};
+    const sandbox = {
+        console,
+        crypto: { randomUUID: () => 'test-session-id' },
+        exports: moduleExports,
+        fetch: fetchStub,
+        Headers,
+        module: { exports: moduleExports },
+        Request,
+        require(specifier) {
+            if (specifier === 'zod') return { z: { object: () => ({}) } };
+            if (specifier === 'zod-to-json-schema') return { zodToJsonSchema: () => ({}) };
+            if (specifier === './tools/toolConfigs.js') return { allToolConfigs: [] };
+            if (specifier === './tools/toolFactory.js') return { invokeTool: async () => ({}) };
+            throw new Error(`Unexpected test import: ${specifier}`);
+        },
+        Response,
+        URL,
+    };
+
+    vm.runInNewContext(compiled, sandbox, { filename: workerPath });
+    return sandbox.module.exports.default;
+}
+
+const env = {
+    OAUTH_ISSUER: 'https://api.coin-stats.com',
+    MCP_RESOURCE_URL: 'https://mcp.coinstats.app',
+};
+
+async function fetchMirroredAuthorizationMetadata(pathname) {
+    let upstreamUrl;
+    const worker = loadWorker(async (url) => {
+        upstreamUrl = String(url);
+        return new Response(
+            JSON.stringify({
+                issuer: 'https://api.coin-stats.com',
+                authorization_endpoint: 'https://coinstats.app/openapi/consent',
+                token_endpoint: 'https://api.coin-stats.com/v1/oauth/token',
+                scopes_supported: ['coinstats', 'admin'],
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } }
+        );
+    });
+
+    const response = await worker.fetch(
+        new Request(`https://mcp.coinstats.app${pathname}`),
+        env
+    );
+    const body = await response.json();
+
+    return { body, response, upstreamUrl };
+}
+
+test('mirrored authorization server metadata advertises the consumer MCP scope only', async () => {
+    const paths = [
+        '/.well-known/oauth-authorization-server',
+        '/mcp/.well-known/oauth-authorization-server',
+        '/.well-known/oauth-authorization-server/mcp',
+    ];
+
+    for (const pathname of paths) {
+        const { body, response, upstreamUrl } =
+            await fetchMirroredAuthorizationMetadata(pathname);
+
+        assert.equal(response.status, 200);
+        assert.equal(
+            upstreamUrl,
+            'https://api.coin-stats.com/.well-known/oauth-authorization-server'
+        );
+        assert.deepEqual(body.scopes_supported, ['coinstats']);
+    }
+});


### PR DESCRIPTION
## Summary

- Narrow the MCP-hosted OAuth authorization-server metadata mirror to the consumer `coinstats` scope.
- Reuse a single `CONSUMER_MCP_SCOPES` constant for protected-resource metadata and compatibility metadata responses.
- Add a Node regression test covering all mirrored authorization metadata paths.

## Root Cause

The protected-resource metadata correctly advertised only `coinstats`, but the compatibility AS metadata mirror forwarded the global authorization server scope list, which now includes `admin`. MCP clients that discover through the mirror can request both `coinstats admin`, and Cloud rejects that combination with `invalid_scope`.

## Validation

- `npm test`
- `npm run build:js`
- `npm exec wrangler -- deploy --dry-run --outdir /private/tmp/coinstats-mcp-worker-dryrun`